### PR TITLE
Fix autostart not applying when enabled in settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use std::thread;
 use std::time::Duration;
 use chrono::{Local, Timelike, Utc};
 use tauri_plugin_notification::NotificationExt;
+use tauri_plugin_autostart::ManagerExt as AutoStartManagerExt;
 
 
 
@@ -367,8 +368,21 @@ async fn get_app_config(state: State<'_, AppState>) -> Result<AppConfig, String>
 }
 
 #[tauri::command]
-async fn set_app_config(state: State<'_, AppState>, config: AppConfig) -> Result<(), String> {
+async fn set_app_config(state: State<'_, AppState>, app_handle: tauri::AppHandle, config: AppConfig) -> Result<(), String> {
     state.config.set_config(config.clone())?;
+
+    if config.start_at_login {
+        app_handle
+            .autolaunch()
+            .enable()
+            .map_err(|e| format!("Falha ao ativar inicialização automática: {e}"))?;
+    } else {
+        app_handle
+            .autolaunch()
+            .disable()
+            .map_err(|e| format!("Falha ao desativar inicialização automática: {e}"))?;
+    }
+
     Ok(())
 }
 
@@ -508,6 +522,13 @@ pub fn run() {
             let config = ConfigManager::new(app.handle());
             let estudos = EstudosManager::new(app.handle());
             let sono = SonoManager::new(app.handle());
+
+            let initial_config = config.get_config();
+            if initial_config.start_at_login {
+                let _ = app.autolaunch().enable();
+            } else {
+                let _ = app.autolaunch().disable();
+            }
             
 
             


### PR DESCRIPTION
### Motivation
- Enabling "Auto-start (Login)" in the settings only persisted the flag in the app config but did not register/unregister the app with the OS autostart system. 
- The app must both persist the setting and call the autostart plugin so the OS behavior matches the stored configuration.

### Description
- Added `tauri_plugin_autostart::ManagerExt` and used `app_handle.autolaunch()` to control OS autostart from the backend. 
- Updated `set_app_config` to accept the `tauri::AppHandle`, persist the `AppConfig`, and immediately call `autolaunch().enable()` or `autolaunch().disable()` based on `start_at_login`. 
- During application `setup`, read the persisted config via `config.get_config()` and synchronize the autostart plugin state so the plugin matches the stored `start_at_login`. 
- Changes are in `src-tauri/src/lib.rs` and committed.

### Testing
- Attempted `cd src-tauri && cargo check` to validate the native integration, but it failed due to the environment missing the system library `glib-2.0` required by `glib-sys` (pkg-config error). 
- Ran `rustfmt` / `cargo fmt` which reported formatting/trailing-whitespace issues in the environment unrelated to the autostart changes. 
- The code changes were committed locally with `git` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdee27fd083329bd208e252ea39b6)