### PR TITLE
fix: prevent startup summary from aborting app

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1648,6 +1648,24 @@ pub fn run() {
 
             // ─── Startup Data Summary ──────────────────────────────────────────
             {
+                use std::panic::{catch_unwind, AssertUnwindSafe};
+
+                fn safe_startup_count<F>(label: &str, f: F) -> usize
+                where
+                    F: FnOnce() -> usize,
+                {
+                    match catch_unwind(AssertUnwindSafe(f)) {
+                        Ok(count) => count,
+                        Err(_) => {
+                            crate::log_warn!(
+                                "Resumo de startup ignorou '{}' porque a leitura falhou; o app continuará abrindo.",
+                                label
+                            );
+                            0
+                        }
+                    }
+                }
+
                 let pm_report  = PasswordManager::new(app.handle());
                 let note_report = notes::NoteManager::new(app.handle());
                 let habit_report = HabitManager::new(app.handle());
@@ -1670,17 +1688,19 @@ pub fn run() {
                         let uid = user_val.get("id").and_then(|v| v.as_str()).unwrap_or("?");
                         let name = user_val.get("username").and_then(|v| v.as_str()).unwrap_or("?");
 
-                        let pw_count = pm_report.list_passwords(uid).map(|v| v.len()).unwrap_or(0);
-                        let note_count = note_report.list_notes(uid).len();
-                        let habit_count = habit_report.list_habits(uid, now_report).len();
-                        let task_count = task_report.list_tasks(uid).len();
-                        let book_count = reading_report.list_books(uid).len();
-                        let sleep_count = sleep_report.list_entries(uid, 1, now_report).len();
-                        let event_count = calendar_report.list_events(uid).len();
-                        let alarm_count = alarm_report.list_alarms(uid).len();
-                        let study_count = studies_report.list_sessions(uid, 12, now_report).len(); // ultimos 12 meses
-                        let dict_count = dict_report.list_words(uid).len();
-                        let movies_count = movies_report.list_movies(uid).len();
+                        let pw_count = safe_startup_count("senhas", || {
+                            pm_report.list_passwords(uid).map(|v| v.len()).unwrap_or(0)
+                        });
+                        let note_count = safe_startup_count("notas", || note_report.list_notes(uid).len());
+                        let habit_count = safe_startup_count("hábitos", || habit_report.list_habits(uid, now_report).len());
+                        let task_count = safe_startup_count("tarefas", || task_report.list_tasks(uid).len());
+                        let book_count = safe_startup_count("leitura", || reading_report.list_books(uid).len());
+                        let sleep_count = safe_startup_count("sono", || sleep_report.list_entries(uid, 1, now_report).len());
+                        let event_count = safe_startup_count("agenda", || calendar_report.list_events(uid).len());
+                        let alarm_count = safe_startup_count("alertas", || alarm_report.list_alarms(uid).len());
+                        let study_count = safe_startup_count("estudos", || studies_report.list_sessions(uid, 12, now_report).len());
+                        let dict_count = safe_startup_count("dicionário", || dict_report.list_words(uid).len());
+                        let movies_count = safe_startup_count("filmes/séries", || movies_report.list_movies(uid).len());
 
                         crate::log_status!("  ┌─ Usuário: {} ({})", name, uid);
                         crate::log_status!("  │  Senhas no cofre : {}", pw_count);
@@ -1698,8 +1718,6 @@ pub fn run() {
                 } else {
                     crate::log_warn!("Não foi possível listar usuários no startup.");
                 }
-
-                
             }
             // ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Startup sequencer previously executed many module/database counts directly during app bootstrap and a panic in any of those reads could abort the whole application start.
- We want to keep the per-user startup summary logs but make them resilient so an occasional module/db failure doesn't prevent Aegis from opening.

### Description
- Add a panic-safe helper `safe_startup_count` that wraps each per-module count in `catch_unwind(AssertUnwindSafe(...))` and returns `0` on failure while logging a warning. (file: `src-tauri/src/lib.rs`)
- Replace direct calls that compute per-user counts (passwords, notes, habits, tasks, reading, sleep, calendar, alarms, studies, dictionary, movies) with calls to `safe_startup_count` so any failing counter is isolated. (file: `src-tauri/src/lib.rs`)
- Keep the existing startup summary output via `crate::log_status!` and emit `crate::log_warn!` when one of the protected counts fails. (file: `src-tauri/src/lib.rs`)

### Testing
- Ran `git diff --check` which reported no new issues and passed. 
- Ran TypeScript checks `npx tsc --noEmit` which completed successfully. 
- Attempted `cargo check --manifest-path src-tauri/Cargo.toml` but it could not finish in the CI/dev environment due to a missing system dependency (`glib-2.0` / `glib-2.0.pc`) required by `glib-sys`. 
- Note: a previous `npm run build` attempt in this environment failed due to a Google Fonts fetch during the Next.js build, which is unrelated to the Rust change but prevented a full end-to-end frontend build here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a029e3870c88332a2f40d6dbcdc760b)