### PR TITLE
Corrige leitura de notas antigas e normaliza frontmatter

### DIFF
--- a/src-tauri/src/notes.rs
+++ b/src-tauri/src/notes.rs
@@ -26,10 +26,11 @@ pub struct FileSystemItem {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 struct NoteMeta {
     pub id: i32,
+    #[serde(rename = "userId", alias = "user_id")]
     pub user_id: String,
+    #[serde(rename = "createdAt", alias = "created_at")]
     pub created_at: String,
     #[serde(default)]
     pub pinned: bool,
@@ -45,22 +46,31 @@ impl NoteManager {
     pub fn new(_app_handle: &AppHandle) -> Self {
         let current_exe = std::env::current_exe().unwrap_or_default();
         let current_dir = std::env::current_dir().unwrap_or_default();
-        
+
         let path_str = current_exe.to_string_lossy();
-        let base_dir = if path_str.contains("target\\debug") || path_str.contains("target\\release") {
+        let base_dir = if path_str.contains("target\\debug") || path_str.contains("target\\release")
+        {
             current_dir
         } else {
             current_exe.parent().unwrap_or(&current_dir).to_path_buf()
         };
-        
+
         let notes_dir = base_dir.join("notes");
         let _ = fs::create_dir_all(&notes_dir);
-        
+
         NoteManager { notes_dir }
     }
 
     fn sanitize_filename(name: &str) -> String {
-        name.chars().map(|c| if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' { c } else { '_' }).collect()
+        name.chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == ' ' || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect()
     }
 
     fn get_note_path(&self, id: i32, title: &str, parent_path: Option<&str>) -> PathBuf {
@@ -99,54 +109,54 @@ impl NoteManager {
     }
 
     fn parse_note_file(&self, path: &PathBuf) -> Result<Note, String> {
-    let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
-    let content = content.replace("\r\n", "\n");
+        let content = fs::read_to_string(path).map_err(|e| e.to_string())?;
+        let content = content.replace("\r\n", "\n");
 
-    if content.starts_with("---\n") {
-        if let Some(end_idx) = content[4..].find("\n---\n") {
-            let frontmatter_str = &content[4..end_idx + 4];
-            let body = &content[end_idx + 9..];
+        if content.starts_with("---\n") {
+            if let Some(end_idx) = content[4..].find("\n---\n") {
+                let frontmatter_str = &content[4..end_idx + 4];
+                let body = &content[end_idx + 9..];
 
-            let meta: NoteMeta =
-                serde_yaml::from_str(frontmatter_str).map_err(|e| e.to_string())?;
+                let meta: NoteMeta =
+                    serde_yaml::from_str(frontmatter_str).map_err(|e| e.to_string())?;
 
-            let mut title = String::new();
-            let mut stripped_body = body;
-            if let Some(first_line) = body.lines().next() {
-                if first_line.starts_with("# ") {
-                    title = first_line[2..].trim().to_string();
-                    if let Some(rest_idx) = body.find('\n') {
-                        stripped_body = &body[rest_idx + 1..];
+                let mut title = String::new();
+                let mut stripped_body = body;
+                if let Some(first_line) = body.lines().next() {
+                    if first_line.starts_with("# ") {
+                        title = first_line[2..].trim().to_string();
+                        if let Some(rest_idx) = body.find('\n') {
+                            stripped_body = &body[rest_idx + 1..];
+                        }
                     }
                 }
+
+                let relative_path = path
+                    .strip_prefix(&self.notes_dir)
+                    .ok()
+                    .and_then(|p| p.parent())
+                    .map(|p| p.to_string_lossy().to_string());
+
+                return Ok(Note {
+                    id: Some(meta.id),
+                    user_id: meta.user_id,
+                    title,
+                    content: stripped_body.trim().to_string(),
+                    created_at: meta.created_at,
+                    pinned: meta.pinned,
+                    path: relative_path,
+                    color: meta.color,
+                });
             }
-
-            let relative_path = path
-                .strip_prefix(&self.notes_dir)
-                .ok()
-                .and_then(|p| p.parent())
-                .map(|p| p.to_string_lossy().to_string());
-
-            return Ok(Note {
-                id: Some(meta.id),
-                user_id: meta.user_id,
-                title,
-                content: stripped_body.trim().to_string(),
-                created_at: meta.created_at,
-                pinned: meta.pinned,
-                path: relative_path,
-                color: meta.color,
-            });
         }
-    }
-        
-        Err("Formato invalido".to_string())
+
+        Err("Formato inválido".to_string())
     }
 
     fn write_note_file(&self, note: &Note) -> Result<(), String> {
         let id = note.id.unwrap_or(0);
         let path = self.get_note_path(id, &note.title, note.path.as_deref());
-        
+
         // Garante que o diretório pai existe
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
@@ -159,10 +169,15 @@ impl NoteManager {
             pinned: note.pinned,
             color: note.color.clone(),
         };
-        
+
         let frontmatter = serde_yaml::to_string(&meta).unwrap_or_default();
-        let content = format!("---\n{}\n---\n# {}\n\n{}", frontmatter.trim(), note.title, note.content);
-        
+        let content = format!(
+            "---\n{}\n---\n# {}\n\n{}",
+            frontmatter.trim(),
+            note.title,
+            note.content
+        );
+
         fs::write(&path, content).map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -177,14 +192,19 @@ impl NoteManager {
         if let Ok(entries) = fs::read_dir(dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                let rel_path = path.strip_prefix(&self.notes_dir)
+                let rel_path = path
+                    .strip_prefix(&self.notes_dir)
                     .unwrap_or(&path)
                     .to_string_lossy()
                     .to_string();
 
                 if path.is_dir() {
                     items.push(FileSystemItem {
-                        name: path.file_name().unwrap_or_default().to_string_lossy().to_string(),
+                        name: path
+                            .file_name()
+                            .unwrap_or_default()
+                            .to_string_lossy()
+                            .to_string(),
                         is_dir: true,
                         path: rel_path,
                         note: None,
@@ -209,7 +229,7 @@ impl NoteManager {
     pub fn add_note(&self, note: Note) -> Result<(), String> {
         let mut next_id = 1;
         self.find_max_id(&self.notes_dir, &mut next_id);
-        
+
         let mut new_note = note.clone();
         new_note.id = Some(next_id);
         self.write_note_file(&new_note)
@@ -280,7 +300,7 @@ impl NoteManager {
     pub fn move_item(&self, source_path: String, dest_path: String) -> Result<(), String> {
         let source = self.notes_dir.join(&source_path);
         let mut dest = self.notes_dir.join(&dest_path);
-        
+
         if !source.exists() {
             return Err("Origem não encontrada".to_string());
         }
@@ -303,9 +323,7 @@ impl NoteManager {
     pub fn list_notes(&self, user_id: &str) -> Vec<Note> {
         let mut notes = Vec::new();
         self.list_notes_recursive(&self.notes_dir, user_id, &mut notes);
-        notes.sort_by(|a, b| {
-            b.pinned.cmp(&a.pinned).then(b.id.cmp(&a.id))
-        });
+        notes.sort_by(|a, b| b.pinned.cmp(&a.pinned).then(b.id.cmp(&a.id)));
         notes
     }
 
@@ -339,3 +357,55 @@ impl NoteManager {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager_for_test(name: &str) -> NoteManager {
+        let dir =
+            std::env::temp_dir().join(format!("aegis_notes_test_{}_{}", name, std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        NoteManager { notes_dir: dir }
+    }
+
+    #[test]
+    fn le_notas_antigas_sem_cor_e_com_metadados_snake_case() {
+        let manager = manager_for_test("snake_case");
+        let path = manager.notes_dir.join("1_Antiga.md");
+        fs::write(
+            &path,
+            "---\nid: 1\nuser_id: usuario\ncreated_at: 2026-05-01T00:00:00Z\npinned: true\n---\n# Antiga\n\nConteúdo antigo",
+        )
+        .unwrap();
+
+        let note = manager.parse_note_file(&path).unwrap();
+
+        assert_eq!(note.id, Some(1));
+        assert_eq!(note.user_id, "usuario");
+        assert_eq!(note.title, "Antiga");
+        assert_eq!(note.content, "Conteúdo antigo");
+        assert!(note.pinned);
+        assert_eq!(note.color, None);
+    }
+
+    #[test]
+    fn le_notas_novas_com_cor_e_metadados_camel_case() {
+        let manager = manager_for_test("camel_case");
+        let path = manager.notes_dir.join("2_Nova.md");
+        fs::write(
+            &path,
+            "---\nid: 2\nuserId: usuario\ncreatedAt: 2026-05-02T00:00:00Z\npinned: false\ncolor: fuchsia\n---\n# Nova\n\nConteúdo novo",
+        )
+        .unwrap();
+
+        let note = manager.parse_note_file(&path).unwrap();
+
+        assert_eq!(note.id, Some(2));
+        assert_eq!(note.user_id, "usuario");
+        assert_eq!(note.title, "Nova");
+        assert_eq!(note.content, "Conteúdo novo");
+        assert!(!note.pinned);
+        assert_eq!(note.color, Some("fuchsia".to_string()));
+    }
+}

--- a/src/components/modules/notes/components/DroppableBreadcrumb.tsx
+++ b/src/components/modules/notes/components/DroppableBreadcrumb.tsx
@@ -12,7 +12,6 @@ interface DroppableBreadcrumbProps {
   isCurrent: boolean;
 }
 
-/** Item de breadcrumb que aceita drops via DnD para mover itens */
 export function DroppableBreadcrumb({
   id,
   children,

--- a/src/components/modules/notes/components/ItemCard.tsx
+++ b/src/components/modules/notes/components/ItemCard.tsx
@@ -36,7 +36,6 @@ interface ItemCardProps {
   searchQuery?: string;
 }
 
-/** Card de arquivo/pasta com suporte a drag-and-drop e menu de contexto */
 export function ItemCard({
   item,
   onNavigate,
@@ -51,7 +50,6 @@ export function ItemCard({
   const isFolder = item.isDir;
   const isPinned = !isFolder && item.note?.pinned;
 
-  // Usar resolveTaskStyles para notas
   const noteStyles =
     !isFolder && item.note ? resolveTaskStyles(item.note.color) : null;
 

--- a/src/components/modules/notes/components/MarkdownToolbar.tsx
+++ b/src/components/modules/notes/components/MarkdownToolbar.tsx
@@ -21,8 +21,6 @@ import { resolveColor, SELECTABLE_COLORS } from "@/colors.config";
 import { ToolTip } from "@/components/ui/ToolTipHelper";
 import { cn } from "@/lib/utils";
 
-// ─── Tipos ────────────────────────────────────────────────────────────────────
-
 type InsertMode =
   | { type: "wrap"; before: string; after: string; placeholder: string }
   | { type: "line-prefix"; prefix: string }
@@ -45,8 +43,6 @@ interface MarkdownToolbarProps {
   onColorChange?: (key: string) => void;
   className?: string;
 }
-
-// ─── Ações do toolbar ─────────────────────────────────────────────────────────
 
 const ACTIONS: ToolbarAction[] = [
   {
@@ -146,8 +142,6 @@ const ACTIONS_BLOCK: ToolbarAction[] = [
   },
 ];
 
-// ─── Função de inserção ───────────────────────────────────────────────────────
-
 function applyInsert(
   textarea: HTMLTextAreaElement,
   value: string,
@@ -215,8 +209,6 @@ function applyInsert(
     textarea.setSelectionRange(newCursorStart, newCursorEnd);
   });
 }
-
-// ─── Color Picker compacto (inline no toolbar) ───────────────────────────────
 
 interface InlineColorPickerProps {
   value: string;
@@ -321,8 +313,6 @@ function InlineColorPicker({ value, onChange }: InlineColorPickerProps) {
   );
 }
 
-// ─── Componente ───────────────────────────────────────────────────────────────
-
 export function MarkdownToolbar({
   textareaRef,
   value,
@@ -338,7 +328,6 @@ export function MarkdownToolbar({
     applyInsert(ta, value, action.insert, onChange);
   };
 
-  // Botão maior (w-9 h-9 em vez de w-7 h-7)
   const btnClass = cn(
     "w-9 h-9 flex items-center justify-center rounded-lg text-muted-foreground",
     "hover:text-foreground hover:bg-white/10 transition-all cursor-pointer active:scale-95",
@@ -354,7 +343,6 @@ export function MarkdownToolbar({
         className,
       )}
     >
-      {/* Headings */}
       {ACTIONS.map((action) => (
         <ToolTip
           key={action.id}
@@ -377,7 +365,6 @@ export function MarkdownToolbar({
 
       {divider}
 
-      {/* Formatação inline */}
       {ACTIONS_FORMAT.map((action) => (
         <ToolTip
           key={action.id}
@@ -400,7 +387,6 @@ export function MarkdownToolbar({
 
       {divider}
 
-      {/* Blocos */}
       {ACTIONS_BLOCK.map((action) => (
         <ToolTip key={action.id} content={action.label}>
           <button
@@ -414,7 +400,6 @@ export function MarkdownToolbar({
         </ToolTip>
       ))}
 
-      {/* Seletor de cor */}
       {onColorChange && (
         <>
           {divider}

--- a/src/components/modules/notes/components/modals/noteCreateModal.tsx
+++ b/src/components/modules/notes/components/modals/noteCreateModal.tsx
@@ -17,9 +17,6 @@ interface NoteCreateModalProps {
   onClose: () => void;
 }
 
-/**
- * Modal para criação de novas notas com visualização em tempo real (Markdown).
- */
 export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
   const [mounted, setMounted] = useState(false);
   const [title, setTitle] = useState("");
@@ -57,9 +54,7 @@ export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
       aria-modal="true"
       aria-labelledby="note-create-title"
     >
-      {/* Container fullscreen com margens mínimas */}
       <div className="relative w-full h-full bg-background border-x border-border animate-in zoom-in-95 duration-200 overflow-hidden flex flex-col">
-        {/* Cabeçalho */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border/60 shrink-0 bg-background/50 backdrop-blur-sm z-10">
           <div className="flex items-center gap-3">
             <div
@@ -105,15 +100,12 @@ export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
           </ToolTip>
         </div>
 
-        {/* Área de Conteúdo Split — ocupa o restante da altura */}
         <div className="flex-1 flex flex-col md:flex-row overflow-hidden min-h-0">
-          {/* Esquerda: Editor */}
           <form
             id="note-form"
             onSubmit={handleSubmit}
             className="flex-1 flex flex-col p-6 gap-4 border-r border-border/50 overflow-hidden"
           >
-            {/* Título */}
             <div className="space-y-2 shrink-0">
               <Label htmlFor="ncm-title" className={lc}>
                 Título da Nota
@@ -129,7 +121,6 @@ export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
               />
             </div>
 
-            {/* Toolbar + Textarea */}
             <div className="flex-1 flex flex-col gap-2 min-h-0">
               <div className="flex items-center justify-between shrink-0">
                 <Label htmlFor="ncm-content" className={lc}>
@@ -163,7 +154,6 @@ export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
             </div>
           </form>
 
-          {/* Direita: Preview com scroll */}
           <div className="flex-1 bg-black/20 flex flex-col overflow-hidden">
             <div className="px-6 py-3 border-b border-border/40 flex items-center gap-2 shrink-0">
               <Eye className="w-3.5 h-3.5 text-muted-foreground" />
@@ -233,7 +223,6 @@ export function NoteCreateModal({ onAdd, onClose }: NoteCreateModalProps) {
           </div>
         </div>
 
-        {/* Rodapé Fixo */}
         <div className="px-6 py-4 border-t border-border shrink-0 bg-background/50 flex gap-3">
           <button
             type="button"

--- a/src/components/modules/notes/components/modals/noteExpandModal.tsx
+++ b/src/components/modules/notes/components/modals/noteExpandModal.tsx
@@ -56,7 +56,6 @@ export function NoteExpandModal({
       zIndex="z-60"
       disableClose={isEditing}
     >
-      {/* Barra de Ferramentas Superior */}
       <div className="flex items-center justify-between p-5 border-b border-neutral-900 bg-background/50 backdrop-blur-xl z-20">
         <div className="flex items-center gap-4 flex-1 mr-4">
           <div
@@ -120,15 +119,11 @@ export function NoteExpandModal({
         </div>
       </div>
 
-      {/* Bloco de cor removido — seletor agora fica no MarkdownToolbar */}
-
-      {/* Área de Visualização/Edição */}
       <div
         className={`flex-1 overflow-hidden flex ${isEditing ? "flex-col lg:flex-row" : "flex-col"}`}
       >
         {isEditing ? (
           <>
-            {/* Editor de Texto */}
             <div className="flex-1 relative w-full lg:w-1/2 border-b lg:border-b-0 lg:border-r border-neutral-900 bg-background flex flex-col">
               <div className="px-8 lg:px-12 pt-4 pb-2 shrink-0">
                 <MarkdownToolbar
@@ -148,7 +143,6 @@ export function NoteExpandModal({
                 placeholder="Escreva sua nota aqui..."
               />
             </div>
-            {/* Preview */}
             <div className="flex-1 h-full w-full lg:w-1/2 overflow-y-auto p-8 lg:p-12 custom-scrollbar bg-card/10">
               <div
                 className={cn(
@@ -193,7 +187,6 @@ export function NoteExpandModal({
             </div>
           </>
         ) : (
-          /* Modo Leitura */
           <div className="flex-1 overflow-y-auto p-8 lg:p-16 custom-scrollbar ">
             <div className="max-w-4xl mx-auto w-full">
               <div

--- a/src/components/modules/notes/components/noteCard.tsx
+++ b/src/components/modules/notes/components/noteCard.tsx
@@ -4,9 +4,7 @@ import { ToolTip } from "@/components/ui/ToolTipHelper";
 import { cn } from "@/lib/utils";
 import type { Note } from "../types";
 
-/**
- * Utilitário para limpar markdown do conteúdo para preview
- */
+// Remove marcações de markdown antes de exibir o resumo.
 const stripMarkdown = (text: string) => {
   if (!text) return "";
   return text
@@ -26,9 +24,6 @@ interface NoteCardProps {
   onDelete: (id: number) => void;
 }
 
-/**
- * Card individual de nota: Suporta preview limpo e fixação
- */
 export function NoteCard({
   note: n,
   onClick,
@@ -51,7 +46,6 @@ export function NoteCard({
         } as React.CSSProperties
       }
     >
-      {/* Clique na área do card */}
       <button
         type="button"
         onClick={onClick}
@@ -70,7 +64,6 @@ export function NoteCard({
           {n.title}
         </p>
 
-        {/* Ações Rápidas (Hover) */}
         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-auto">
           <ToolTip content={n.pinned ? "Desafixar" : "Fixar nota"}>
             <button
@@ -109,14 +102,12 @@ export function NoteCard({
         </div>
       </div>
 
-      {/* Preview do conteúdo truncado */}
       {n.content && (
         <div className="relative z-10 text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap leading-relaxed pl-6 pointer-events-none opacity-80">
           {stripMarkdown(n.content)}
         </div>
       )}
 
-      {/* Rodapé do Card */}
       <div className="relative z-10 mt-auto pt-2 border-t border-border/50 pl-6 flex items-center justify-between pointer-events-none">
         <p className="text-[10px] text-muted-foreground/60 font-bold uppercase">
           {new Date(n.createdAt).toLocaleDateString("pt-BR")}

--- a/src/components/modules/notes/index.tsx
+++ b/src/components/modules/notes/index.tsx
@@ -17,7 +17,7 @@ import { CONFIRM_PRESETS, ConfirmModal } from "@/components/ui/ConfirmModal";
 import { useAuth } from "@/context/AuthContext";
 import { getModuleColor } from "@/modules.config";
 
-// Lazy import: @dnd-kit só carrega quando o módulo de Notas for aberto
+// O gerenciador usa DnD e só é carregado ao abrir Notas.
 const FileManager = lazy(() =>
   import("./components/FileManager").then((m) => ({ default: m.FileManager })),
 );
@@ -27,9 +27,6 @@ import type { Note } from "./types";
 
 const MAX_PINS = 3;
 
-/**
- * Módulo de Notas: Gestão de anotações com suporte a markdown, fixação e status
- */
 export default function NotesPage() {
   const { user } = useAuth();
   const [notes, setNotes] = useState<Note[]>([]);
@@ -41,7 +38,6 @@ export default function NotesPage() {
   const [editMode, setEditMode] = useState(false);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  // Estados compartilhados com o Header e FileManager
   const [searchQuery, setSearchQuery] = useState("");
   const [isFolderModalOpen, setIsFolderModalOpen] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
@@ -226,7 +222,6 @@ export default function NotesPage() {
         />
       </Suspense>
 
-      {/* Confirmação */}
       {deletingId !== null && (
         <ConfirmModal
           {...CONFIRM_PRESETS.deleteNote}

--- a/src/components/modules/notes/noteCard.tsx
+++ b/src/components/modules/notes/noteCard.tsx
@@ -12,12 +12,12 @@ interface NoteCardProps {
 const stripMarkdown = (text: string) => {
   if (!text) return "";
   return text
-    .replace(/^#+\s+/gm, "") // Remove headers
-    .replace(/(\*\*|__)(.*?)\1/g, "$2") // Remove bold
-    .replace(/(\*|_)(.*?)\1/g, "$2") // Remove italic
-    .replace(/~~(.*?)~~/g, "$1") // Remove strikethrough
-    .replace(/`{1,3}([^`\n]+)`{1,3}/g, "$1") // Remove inline code
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // Remove links
+    .replace(/^#+\s+/gm, "")
+    .replace(/(\*\*|__)(.*?)\1/g, "$2")
+    .replace(/(\*|_)(.*?)\1/g, "$2")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/`{1,3}([^`\n]+)`{1,3}/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
     .trim();
 };
 

--- a/src/components/modules/notes/statsCard.tsx
+++ b/src/components/modules/notes/statsCard.tsx
@@ -6,9 +6,6 @@ interface StatsCardProps {
   count: number;
 }
 
-/**
- * Card de estatística simples para o resumo de notas
- */
 export function StatsCard({ count }: StatsCardProps) {
   const theme = getColorTheme(getModuleColor("notes"));
   return (


### PR DESCRIPTION
### Motivation
- Garantir compatibilidade com notas antigas em Markdown que usam frontmatter em snake_case (`user_id`, `created_at`) após introdução do campo `color` em camelCase.
- Simplificar comentários do módulo de Notas para PT-BR e remover comentários decorativos sem alterar a lógica funcional.

### Description
- Ajusta `NoteMeta` em `src-tauri/src/notes.rs` para aceitar ambos os formatos de frontmatter, adicionando `#[serde(rename = "userId", alias = "user_id")]` e `#[serde(rename = "createdAt", alias = "created_at")]`, preservando `pinned`/`color` como opcionais.
- Mantém/ajusta a lógica de parsing em `parse_note_file` para retornar `Note` mesmo quando `color` está ausente e corrige mensagem de erro para português.
- Pequenas refatorações em `notes.rs` (format/collect helpers, `sanitize_filename` legível, formatação de `format!` multi-linha) e adiciona testes unitários que cobrem leitura de notas antigas sem `color` e notas novas com `color`.
- Remove comentários decorativos e reduz o ruído em vários arquivos TypeScript do módulo de Notas, mantendo comentários curtos em pt-BR onde ajudam a explicar a lógica (arquivos afetados em `src/components/modules/notes/...`).

### Testing
- Executado `npx @biomejs/biome check` sobre os componentes de Notas; verificação passou com sucesso.
- Executado `rustfmt --check src/notes.rs`; verificação passou com sucesso para o arquivo alterado.
- Executado `cargo test notes`; não concluiu no ambiente CI por falta da biblioteca de sistema `glib-2.0` exigida por `glib-sys` (ambiente sem dependência nativa), logo os testes Rust não puderam ser finalizados aqui.
- Tentativa de `cargo fmt` global falhou por trailing whitespace em arquivos fora do escopo modificado; apenas `src-tauri/src/notes.rs` foi formatado/verificado com `rustfmt --check` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034691bbdc83329e27a462b5d96876)